### PR TITLE
webpack: Add low cost library check into loader flow

### DIFF
--- a/packages/embedded-css-template-strings-webpack-loader/src/index.ts
+++ b/packages/embedded-css-template-strings-webpack-loader/src/index.ts
@@ -2,6 +2,7 @@ import type webpack from "webpack";
 
 const extractEmbeddedStylesLoader = require.resolve("./extract-embedded-styles");
 
+const LIBRARY_REGEXP = /from ('|")cssup('|")/;
 const STYLES_REGEXP = /const (.*?) = css`((.|\s)*?)`/;
 
 /**
@@ -23,8 +24,15 @@ export default function cssupWebpackLoader(
   this: webpack.LoaderContext<Record<string, never>>,
   source: string
 ) {
+  // Quick check: is there a css`` template string in this module
+  // TODO: configurable template string tag
   const embeddedStylesMatch = STYLES_REGEXP.exec(source);
   if (!embeddedStylesMatch) return source;
+
+  // Quick check: is there an import from the embedded template string library
+  // TODO: configurable library import
+  const libraryMatch = LIBRARY_REGEXP.exec(source);
+  if (!libraryMatch) return source;
 
   // Remove the embedded styles from the original source before passing
   // content to next loader

--- a/packages/embedded-css-template-strings-webpack-loader/test/package-lock.json
+++ b/packages/embedded-css-template-strings-webpack-loader/test/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "test-cssup-webpack-loader",
+  "name": "test-embedded-css-template-strings-webpack-loader",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "test-cssup-webpack-loader",
+      "name": "test-embedded-css-template-strings-webpack-loader",
       "version": "0.0.0",
       "dependencies": {
+        "cssup": "0.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -17,7 +18,7 @@
         "@babel/preset-react": "^7.18.6",
         "babel-loader": "^9.1.0",
         "css-loader": "^6.7.2",
-        "cssup-loader": "file:..",
+        "embedded-css-template-strings-webpack-loader": "file:..",
         "html-webpack-plugin": "^5.5.0",
         "mini-css-extract-plugin": "^2.7.2",
         "postcss": "^8.4.19",
@@ -30,11 +31,18 @@
       }
     },
     "..": {
-      "name": "cssup-webpack-loader",
-      "version": "0.0.1",
+      "version": "0.4.0",
       "dev": true,
       "license": "ISC",
-      "devDependencies": {}
+      "devDependencies": {
+        "eslint-config-cssup": "*",
+        "prettier-config-cssup": "*",
+        "tsconfig-config-cssup": "*",
+        "webpack": "5.75.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -3053,9 +3061,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssup-loader": {
-      "resolved": "..",
-      "link": true
+    "node_modules/cssup": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cssup/-/cssup-0.4.0.tgz",
+      "integrity": "sha512-DeQ2p1T2Hu4lF8pY1LRV3S3Lyhvu3C1yo1ARMNd4BI1Hi54gzSjw+0UBfKxPs1ww7gJeqJ5xGQanOE9Gv2gqQg=="
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -3215,6 +3224,10 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
+    },
+    "node_modules/embedded-css-template-strings-webpack-loader": {
+      "resolved": "..",
+      "link": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -8747,8 +8760,10 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
-    "cssup-loader": {
-      "version": "file:.."
+    "cssup": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cssup/-/cssup-0.4.0.tgz",
+      "integrity": "sha512-DeQ2p1T2Hu4lF8pY1LRV3S3Lyhvu3C1yo1ARMNd4BI1Hi54gzSjw+0UBfKxPs1ww7gJeqJ5xGQanOE9Gv2gqQg=="
     },
     "debug": {
       "version": "2.6.9",
@@ -8874,6 +8889,15 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
+    },
+    "embedded-css-template-strings-webpack-loader": {
+      "version": "file:..",
+      "requires": {
+        "eslint-config-cssup": "*",
+        "prettier-config-cssup": "*",
+        "tsconfig-config-cssup": "*",
+        "webpack": "5.75.0"
+      }
     },
     "encodeurl": {
       "version": "1.0.2",

--- a/packages/embedded-css-template-strings-webpack-loader/test/package.json
+++ b/packages/embedded-css-template-strings-webpack-loader/test/package.json
@@ -7,6 +7,7 @@
     "start": "webpack serve --open"
   },
   "dependencies": {
+    "cssup": "0.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/embedded-css-template-strings-webpack-loader/test/src/App.js
+++ b/packages/embedded-css-template-strings-webpack-loader/test/src/App.js
@@ -1,3 +1,5 @@
+import { css } from "cssup";
+
 const styles = css`
   .header {
     font-size: 3rem;
@@ -24,5 +26,3 @@ export default function App() {
     </div>
   );
 }
-
-function css() {}

--- a/packages/embedded-css-template-strings-webpack-loader/test/webpack.config.js
+++ b/packages/embedded-css-template-strings-webpack-loader/test/webpack.config.js
@@ -39,7 +39,10 @@ module.exports = {
             loader: "css-loader",
             // When using the cssup-loader modules _must_ be set to true, the auto detection no longer works 🤔
             options: {
-              modules: true,
+              modules: {
+                mode: "local",
+                localIdentName: "[name]_[local]_[hash:base64:5]",
+              },
             },
           },
           "postcss-loader",


### PR DESCRIPTION
Adds a low cost check for library imports - the intent of this is to provide some more ways to selectively run this workflow in a large codebase using multiple styling workflows.

These options will become configurable and enable moving modules selectively to embedded template strings with cssup.