### PR TITLE
webpack: Support variableless usage

### DIFF
--- a/packages/embedded-css-template-strings-webpack-loader/src/extract-embedded-styles.ts
+++ b/packages/embedded-css-template-strings-webpack-loader/src/extract-embedded-styles.ts
@@ -1,6 +1,6 @@
 import type webpack from "webpack";
 
-const STYLES_REGEXP = /const (.*?) = css`((.|\s)*?)`/;
+const STYLES_REGEXP = /(const (.*?) = )?css`((.|\s)*?)`/;
 
 export default function extractEmbeddedStylesLoader(
   this: webpack.LoaderContext<Record<string, never>>,
@@ -17,5 +17,5 @@ export default function extractEmbeddedStylesLoader(
     );
     return "";
   }
-  return match[2];
+  return match[3];
 }

--- a/packages/embedded-css-template-strings-webpack-loader/src/index.ts
+++ b/packages/embedded-css-template-strings-webpack-loader/src/index.ts
@@ -3,7 +3,7 @@ import type webpack from "webpack";
 const extractEmbeddedStylesLoader = require.resolve("./extract-embedded-styles");
 
 const LIBRARY_REGEXP = /from ('|")cssup('|")/;
-const STYLES_REGEXP = /const (.*?) = css`((.|\s)*?)`/;
+const STYLES_REGEXP = /(const (.*?) = )?css`((.|\s)*?)`/;
 
 /**
  * Loader that converts embedded css template strings to css module imports.
@@ -41,7 +41,7 @@ export default function cssupWebpackLoader(
   // Use the "inline match resource" syntax to create a new request to the
   // extractEmbeddedStylesLoader
   // ref: https://webpack.js.org/api/loaders/#inline-matchresource
-  return `import ${embeddedStylesMatch[1]} from ${JSON.stringify(
+  return `import ${embeddedStylesMatch[2]} from ${JSON.stringify(
     this.utils.contextify(
       this.context || this.rootContext,
       `${this.resource}.module.css!=!${extractEmbeddedStylesLoader}!${this.remainingRequest}`

--- a/packages/embedded-css-template-strings-webpack-loader/test/src/App.js
+++ b/packages/embedded-css-template-strings-webpack-loader/test/src/App.js
@@ -1,5 +1,7 @@
 import { css } from "cssup";
 
+import { Title } from "./Title";
+
 const styles = css`
   .app {
     max-width: 800px;
@@ -16,7 +18,7 @@ export default function App() {
   return (
     <div className={styles.app}>
       <h1 className={styles.title}>CSS🆙</h1>
-      <h2>Write component styles as embedded CSS template strings.</h2>
+      <Title />
     </div>
   );
 }

--- a/packages/embedded-css-template-strings-webpack-loader/test/src/Title.js
+++ b/packages/embedded-css-template-strings-webpack-loader/test/src/Title.js
@@ -1,0 +1,17 @@
+import { css } from "cssup";
+
+css`
+  :global {
+    .fancy-title {
+      color: teal;
+    }
+  }
+`;
+
+export function Title() {
+  return (
+    <h2 className="fancy-title">
+      Write component styles as embedded CSS template strings.
+    </h2>
+  );
+}


### PR DESCRIPTION
Support template strings without a variable to support `:global` workflows.