### PR TITLE
#12: Fix exporting style declaration

### DIFF
--- a/packages/embedded-css-template-strings-webpack-loader/.eslintrc.js
+++ b/packages/embedded-css-template-strings-webpack-loader/.eslintrc.js
@@ -1,6 +1,9 @@
 module.exports = {
   root: true,
   extends: ["cssup"],
+  env: {
+    browser: true,
+  },
   parserOptions: {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.json"],

--- a/packages/embedded-css-template-strings-webpack-loader/README.md
+++ b/packages/embedded-css-template-strings-webpack-loader/README.md
@@ -15,7 +15,7 @@ npm run watch --workspace=embedded-css-template-strings-webpack-loader
 **Change into the test directory and start the webpack server**
 
 ```
-cd packages/cssup-webpack-laoder/test
+cd packages/embedded-css-template-strings-webpack-loader/test
 npm start
 ```
 

--- a/packages/embedded-css-template-strings-webpack-loader/test/src/App.js
+++ b/packages/embedded-css-template-strings-webpack-loader/test/src/App.js
@@ -1,24 +1,11 @@
-import { css } from "cssup";
-
 import { Title } from "./Title";
-
-const styles = css`
-  .app {
-    max-width: 800px;
-    margin: auto;
-  }
-
-  .title {
-    font-size: 3rem;
-    color: hotpink;
-  }
-`;
+import { Subtitle } from "./Subtitle";
 
 export default function App() {
   return (
-    <div className={styles.app}>
-      <h1 className={styles.title}>CSS🆙</h1>
+    <div>
       <Title />
+      <Subtitle />
     </div>
   );
 }

--- a/packages/embedded-css-template-strings-webpack-loader/test/src/Subtitle.js
+++ b/packages/embedded-css-template-strings-webpack-loader/test/src/Subtitle.js
@@ -1,0 +1,26 @@
+/**
+ * @module
+ * Test case for global styles usage pattern, where the template string isn't
+ * assigned to a variable.
+ */
+
+import { css } from "cssup";
+import { layoutStyles } from "./shared";
+
+css`
+  :global {
+    .fancy-title {
+      color: teal;
+    }
+  }
+`;
+
+export function Subtitle() {
+  return (
+    <div className={layoutStyles.container}>
+      <h2 className="fancy-title">
+        Write component styles as embedded CSS template strings.
+      </h2>
+    </div>
+  );
+}

--- a/packages/embedded-css-template-strings-webpack-loader/test/src/Title.js
+++ b/packages/embedded-css-template-strings-webpack-loader/test/src/Title.js
@@ -1,17 +1,23 @@
-import { css } from "cssup";
+/**
+ * @module
+ * Test case for CSS modules usage pattern, where the style declaration should
+ * be locally scoped to the component
+ */
 
-css`
-  :global {
-    .fancy-title {
-      color: teal;
-    }
+import { css } from "cssup";
+import { layoutStyles } from "./shared";
+
+const styles = css`
+  .title {
+    font-size: 3rem;
+    color: hotpink;
   }
 `;
 
 export function Title() {
   return (
-    <h2 className="fancy-title">
-      Write component styles as embedded CSS template strings.
-    </h2>
+    <div className={layoutStyles.container}>
+      <h1 className={styles.title}>CSS🆙</h1>
+    </div>
   );
 }

--- a/packages/embedded-css-template-strings-webpack-loader/test/src/shared.js
+++ b/packages/embedded-css-template-strings-webpack-loader/test/src/shared.js
@@ -1,0 +1,15 @@
+/**
+ * @module
+ * Test case for exporting style declaration for use in other files
+ */
+
+import { css } from "cssup";
+
+export const layoutStyles = css`
+  .container {
+    max-width: 700px;
+    margin: auto;
+  }
+`;
+
+console.log("SHARED FILE CODE PRESERVED ✔️");


### PR DESCRIPTION
Fixes #12 by adding a check for an export declaration in the styles match.

If one is found the updated source includes the correct pass-through export.